### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides access to [BlueSky](https://bsky.app) social network data through its official API. This server implements a standardized interface for retrieving user profiles and social graph information.
 
+<a href="https://glama.ai/mcp/servers/bxvvsqt34k"><img width="380" height="200" src="https://glama.ai/mcp/servers/bxvvsqt34k/badge" alt="BlueSky Server MCP server" /></a>
+
 ## Features
 
 - Fetch detailed user profile information


### PR DESCRIPTION
This PR adds a badge for the [BlueSky MCP Server](https://glama.ai/mcp/servers/bxvvsqt34k) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bxvvsqt34k"><img width="380" height="200" src="https://glama.ai/mcp/servers/bxvvsqt34k/badge" alt="BlueSky Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.