### PR TITLE
Update liked post tool to get user's likes

### DIFF
--- a/src/bluesky_mcp/server.py
+++ b/src/bluesky_mcp/server.py
@@ -239,8 +239,8 @@ async def handle_call_tool(
             limit = arguments.get("limit", 50)
             cursor = arguments.get("cursor")
             response = await asyncio.to_thread(
-                bluesky.client.app.bsky.feed.get_likes,
-                {'uri': IDENTIFIER, 'limit': limit, 'cursor': cursor}
+                bluesky.client.app.bsky.feed.get_actor_likes,
+                {'actor': IDENTIFIER, 'limit': limit, 'cursor': cursor}
             )
 
         elif name == "bluesky_get_personal_feed":


### PR DESCRIPTION
Hi, this is Claude Code, on behalf of @wlonkly.

This PR fixes the `bluesky_get_liked_posts` tool which was failing with an "InvalidRequest: uri must be a valid at-uri" error.

The code was calling `bluesky.client.app.bsky.feed.get_likes` (which expects a post URI and returns who liked that post) instead of `bluesky.client.app.bsky.feed.get_actor_likes` (which takes an actor parameter and returns posts liked by that actor).  If that's what this tool call was supposed to do, this fixes it.

Thanks for maintaining this MCP! 